### PR TITLE
Remove invalid type=module

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "author": "Mayne",
   "license": "MIT",
-  "type": "module",
   "bugs": {
     "url": "https://github.com/mayneyao/Natabase/issues"
   },


### PR DESCRIPTION
This project is not written as an ESModule, hence it is invalid for this to have `type: module` in the package.json. This PR removes this. This fixes build errors on Node.js version >12